### PR TITLE
webp Support for (deprecated) J3 Image Package

### DIFF
--- a/libraries/vendor/joomla/image/src/Image.php
+++ b/libraries/vendor/joomla/image/src/Image.php
@@ -130,6 +130,7 @@ class Image implements LoggerAwareInterface
 			static::$formats[IMAGETYPE_JPEG] = ($info['JPEG Support']) ? true : false;
 			static::$formats[IMAGETYPE_PNG]  = ($info['PNG Support']) ? true : false;
 			static::$formats[IMAGETYPE_GIF]  = ($info['GIF Read Support']) ? true : false;
+			static::$formats[IMAGETYPE_WEBP]  = ($info['WebP Support']) ? true : false;
 		}
 
 		// If the source input is a resource, set it as the image handle.
@@ -714,6 +715,31 @@ class Image implements LoggerAwareInterface
 
 				break;
 
+			case 'image/webp':
+				// Make sure the image type is supported.
+				if (empty(static::$formats[IMAGETYPE_WEBP])) {
+					// @codeCoverageIgnoreStart
+					$this->getLogger()->error('Attempting to load an image of unsupported type WebP.');	
+					
+				    	throw new \RuntimeException('Attempting to load an image of unsupported type WebP.');
+					
+					// @codeCoverageIgnoreEnd
+				}
+
+				// Attempt to create the image handle.
+				$handle = imagecreatefromwebp($path);
+
+				if (!$this->isValidImage($handle)) {
+					// @codeCoverageIgnoreStart
+					throw new \RuntimeException('Unable to process WebP image.');
+
+					// @codeCoverageIgnoreEnd
+				}
+
+				$this->handle = $handle;
+
+				break;				
+				
 			default:
 				$this->getLogger()->error('Attempting to load an image of unsupported type ' . $properties->mime);
 


### PR DESCRIPTION
A lot of people will continue to use Joomla 3 for some time, yet they want to use WebP images. 
This is a small adjustment to let extensions like media manager accomplish that. Our extensions are using the J4 WebP support for resizing and stuff, and this would be good to offer WebP for all the J3 people still around.

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions
```
$fullpath = 'path/to/image.webp';
$fullpath_resized = 'path/to/image_resized.webp';

try {
    $image = new Image($fullpath);
} catch (Exception $e) {
    return false;
}

$properties = $image->getImageFileProperties($fullpath);

switch ($properties->mime) {
    case 'image/webp':
        $imageType = \IMAGETYPE_WEBP;
        break;
    case 'image/png':
        $imageType = \IMAGETYPE_PNG;
        break;
    case 'image/gif':
        $imageType = \IMAGETYPE_GIF;
        break;
    default:
        $imageType = \IMAGETYPE_JPEG;
}

$image = $image->cropResize(1024, 768);
$image->toFile($fullpath_resized, $imageType, ['quality' => 85]);
```


### Actual result BEFORE applying this Pull Request
Attempting to load an image of unsupported type WebP


### Expected result AFTER applying this Pull Request
Successful handling of WebP images


### Documentation Changes Required

